### PR TITLE
Fix #10 - resolve filepath characters such as `.`, `..`, and `~`.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nats-io/nats-account-server
 require (
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/julienschmidt/httprouter v1.2.0
+	github.com/mitchellh/go-homedir v1.0.0
 	github.com/nats-io/go-nats v1.7.2
 	github.com/nats-io/jwt v0.2.4
 	github.com/nats-io/nats-server v0.0.0-20190506224138-6584a9a8283f


### PR DESCRIPTION
 Added a dependency on homedir lib to resolve home `~`, and added a function to expand all paths to their absolute equivalent.