### PR TITLE
Added support for replica mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ install: build
 	go install ./...
 
 cover: test
-	go tool cover -html=./coverage.out -tags test
+	go tool cover -html=./coverage.out
 
 test: check
 	go mod vendor
 	rm -rf ./cover.out
-	go test -race -coverpkg=./server/... -coverprofile=./coverage.out ./...
+	go test -tags test -race -coverpkg=./server/... -coverprofile=./coverage.out ./...
 
 fasttest:
 	scripts/cov.sh

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/julienschmidt/httprouter v1.2.0
 	github.com/mitchellh/go-homedir v1.0.0
+	github.com/nats-io/gnatsd v1.4.1 // indirect
 	github.com/nats-io/go-nats v1.7.2
 	github.com/nats-io/jwt v0.2.4
 	github.com/nats-io/nats-server v0.0.0-20190506224138-6584a9a8283f

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 	flag.StringVar(&flags.Directory, "dir", "", "the directory to store/host accounts with, mututally exclusive from nsc")
 	flag.StringVar(&flags.NATSURL, "nats", "", "the NATS server to use for notifications, the default is no notifications")
 	flag.StringVar(&flags.Creds, "creds", "", "the creds file for connecting to NATS")
+	flag.StringVar(&flags.Primary, "primary", "", "the URL for the primary server, in the form http(s)://host:port/")
 	flag.BoolVar(&flags.Debug, "D", false, "turn on debug logging")
 	flag.BoolVar(&flags.Verbose, "V", false, "turn on verbose logging")
 	flag.BoolVar(&flags.DebugAndVerbose, "DV", false, "turn on debug and verbose logging")

--- a/server/conf/conf.go
+++ b/server/conf/conf.go
@@ -29,6 +29,9 @@ type AccountServerConfig struct {
 
 	OperatorJWTPath      string
 	SystemAccountJWTPath string
+
+	Primary            string
+	ReplicationTimeout int //milliseconds
 }
 
 // TLSConf holds the configuration for a TLS connection/server
@@ -92,6 +95,7 @@ func DefaultServerConfig() AccountServerConfig {
 			ReconnectWait:  1000,
 			MaxReconnects:  0,
 		},
-		Store: StoreConfig{}, // in memory store
+		Store:              StoreConfig{}, // in memory store
+		ReplicationTimeout: 5000,
 	}
 }

--- a/server/conf/conf_test.go
+++ b/server/conf/conf_test.go
@@ -27,4 +27,5 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, false, config.Logging.Trace)
 	require.Equal(t, 5000, config.HTTP.ReadTimeout)
 	require.Equal(t, 5000, config.NATS.ConnectTimeout)
+	require.Equal(t, 5000, config.ReplicationTimeout)
 }

--- a/server/core/flags.go
+++ b/server/core/flags.go
@@ -19,4 +19,6 @@ type Flags struct {
 	DebugAndVerbose bool
 
 	HostPort string
+
+	Primary string
 }

--- a/server/core/handlers_replica_test.go
+++ b/server/core/handlers_replica_test.go
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2019 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package core
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/nats-io/jwt"
+	"github.com/nats-io/nats-account-server/server/conf"
+	"github.com/nats-io/nkeys"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetReplicatedJWT(t *testing.T) {
+	testEnv, err := SetupTestServer(conf.DefaultServerConfig(), false, true)
+	defer testEnv.Cleanup()
+	require.NoError(t, err)
+
+	// Put an account on the main server
+	accountKey, err := nkeys.CreateAccount()
+	require.NoError(t, err)
+
+	pubKey, err := accountKey.PublicKey()
+	require.NoError(t, err)
+
+	account := jwt.NewAccountClaims(pubKey)
+	account.Expires = time.Now().Add(24 * time.Hour).Unix()
+	acctJWT, err := account.Encode(testEnv.OperatorKey)
+	require.NoError(t, err)
+
+	path := fmt.Sprintf("/jwt/v1/accounts/%s", pubKey)
+	url := testEnv.URLForPath(path)
+
+	resp, err := testEnv.HTTP.Post(url, "application/json", bytes.NewBuffer([]byte(acctJWT)))
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+
+	// Get the URL from the main server
+	resp, err = testEnv.HTTP.Get(url)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	savedJWT := string(body)
+
+	// Now start up the replica
+	replica, err := testEnv.CreateReplica("")
+	require.NoError(t, err)
+	defer replica.Stop()
+
+	// Try to get the account from the replica
+
+	url = fmt.Sprintf("%s://%s%s", replica.protocol, replica.hostPort, path)
+	resp, err = testEnv.HTTP.Get(url)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	replicatedJWT := string(body)
+
+	require.Equal(t, savedJWT, replicatedJWT)
+
+	// Update the account
+	account.Tags = append(account.Tags, "alpha")
+	acctJWT, err = account.Encode(testEnv.OperatorKey)
+	require.NoError(t, err)
+
+	url = testEnv.URLForPath(path)
+	resp, err = testEnv.HTTP.Post(url, "application/json", bytes.NewBuffer([]byte(acctJWT)))
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+
+	// Let the nats notification propogate
+	time.Sleep(3 * time.Second)
+
+	// Check that they match
+	resp, err = testEnv.HTTP.Get(url)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	savedJWT = string(body)
+
+	url = fmt.Sprintf("%s://%s%s", replica.protocol, replica.hostPort, path)
+	resp, err = testEnv.HTTP.Get(url)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	replicatedJWT = string(body)
+
+	require.Equal(t, savedJWT, replicatedJWT)
+
+	// set the pub key to stale
+	replica.validUntil[pubKey] = time.Now().Add(-time.Hour)
+
+	resp, err = testEnv.HTTP.Get(url)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	forcedReload := string(body)
+
+	require.Equal(t, savedJWT, forcedReload)
+}
+
+func TestReplicationDefaultsToOnDisk(t *testing.T) {
+	testEnv, err := SetupTestServer(conf.DefaultServerConfig(), false, true)
+	defer testEnv.Cleanup()
+	require.NoError(t, err)
+
+	// Put an account on the main server
+	accountKey, err := nkeys.CreateAccount()
+	require.NoError(t, err)
+
+	pubKey, err := accountKey.PublicKey()
+	require.NoError(t, err)
+
+	account := jwt.NewAccountClaims(pubKey)
+	acctJWT, err := account.Encode(testEnv.OperatorKey)
+	require.NoError(t, err)
+
+	path := fmt.Sprintf("/jwt/v1/accounts/%s", pubKey)
+	url := testEnv.URLForPath(path)
+
+	resp, err := testEnv.HTTP.Post(url, "application/json", bytes.NewBuffer([]byte(acctJWT)))
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+
+	// Now start up the replica
+	replica, err := testEnv.CreateReplica("")
+	require.NoError(t, err)
+	defer replica.Stop()
+
+	// Fill the cache
+	url = fmt.Sprintf("%s://%s%s", replica.protocol, replica.hostPort, path)
+	resp, err = testEnv.HTTP.Get(url)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	replicatedJWT := string(body)
+
+	// Turn off the main server
+	testEnv.Server.Stop()
+
+	// Get the JWT again
+	resp, err = testEnv.HTTP.Get(url)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	primaryDown := string(body)
+
+	require.Equal(t, replicatedJWT, primaryDown)
+
+	// remove the pub key from the cache tracker
+	delete(replica.validUntil, pubKey)
+
+	resp, err = testEnv.HTTP.Get(url)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	forcedToUseDisk := string(body)
+
+	require.Equal(t, replicatedJWT, forcedToUseDisk)
+}
+
+func TestReplicatedFromDir(t *testing.T) {
+	testEnv, err := SetupTestServer(conf.DefaultServerConfig(), false, true)
+	defer testEnv.Cleanup()
+	require.NoError(t, err)
+
+	// Put an account on the main server
+	accountKey, err := nkeys.CreateAccount()
+	require.NoError(t, err)
+
+	pubKey, err := accountKey.PublicKey()
+	require.NoError(t, err)
+
+	account := jwt.NewAccountClaims(pubKey)
+	acctJWT, err := account.Encode(testEnv.OperatorKey)
+	require.NoError(t, err)
+
+	path := fmt.Sprintf("/jwt/v1/accounts/%s", pubKey)
+	url := testEnv.URLForPath(path)
+
+	resp, err := testEnv.HTTP.Post(url, "application/json", bytes.NewBuffer([]byte(acctJWT)))
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+
+	// Now start up the replica
+	tempDir, err := ioutil.TempDir(os.TempDir(), "prefix")
+	require.NoError(t, err)
+
+	replica, err := testEnv.CreateReplica(tempDir)
+	require.NoError(t, err)
+	defer replica.Stop()
+
+	// Fill the cache
+	url = fmt.Sprintf("%s://%s%s", replica.protocol, replica.hostPort, path)
+	resp, err = testEnv.HTTP.Get(url)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	replicatedJWT := string(body)
+
+	// Turn off the main server
+	testEnv.Server.Stop()
+
+	// Get the JWT again
+	resp, err = testEnv.HTTP.Get(url)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	primaryDown := string(body)
+
+	require.Equal(t, replicatedJWT, primaryDown)
+
+	// remove the pub key from the cache tracker
+	delete(replica.validUntil, pubKey)
+
+	resp, err = testEnv.HTTP.Get(url)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	forcedToUseDisk := string(body)
+
+	require.Equal(t, replicatedJWT, forcedToUseDisk)
+}

--- a/server/core/http.go
+++ b/server/core/http.go
@@ -175,7 +175,9 @@ func (server *AccountServer) buildRouter() (*httprouter.Router, error) {
 
 	r.GET("/jwt/v1/help", server.JWTHelp)
 
-	if !server.jwtStore.IsReadOnly() {
+	// replicas and readonly stores cannot accept post requests
+	// replicas use a writable store, thus the extra check
+	if !server.jwtStore.IsReadOnly() && server.primary == "" {
 		r.POST("/jwt/v1/accounts/:pubkey", server.UpdateAccountJWT)
 	}
 

--- a/server/core/server_test.go
+++ b/server/core/server_test.go
@@ -205,6 +205,23 @@ func (ts *TestSetup) initKeys() error {
 	return nil
 }
 
+func (ts *TestSetup) CreateReplica(dir string) (*AccountServer, error) {
+	config := conf.DefaultServerConfig()
+	config.Primary = ts.URLForPath("/")
+	config.NATS = ts.Server.config.NATS
+	config.HTTP.Port = int(atomic.AddUint64(&port, 1))
+	config.OperatorJWTPath = ts.OperatorJWTFile
+	config.SystemAccountJWTPath = ts.SystemAccountJWTFile
+	config.Logging.Trace = true
+	config.Logging.Debug = true
+	config.Store.Dir = dir
+	config.HTTP.TLS = ts.Server.config.HTTP.TLS
+
+	replica := NewAccountServer()
+	replica.InitializeFromConfig(config)
+	return replica, replica.Start()
+}
+
 var port = uint64(14222)
 
 // SetupTestServer creates an operator, gnatsd, context, config and test http server with a router


### PR DESCRIPTION
Replica mode works with directory or memory stores
Replicas listen to nats for updates
Replicas use the cache time to ask for stale updates
Replicas can host JWTs even if the primary is down