### PR TITLE
Added support for an initial JWT pack for replicas

### DIFF
--- a/server/conf/conf.go
+++ b/server/conf/conf.go
@@ -32,6 +32,7 @@ type AccountServerConfig struct {
 
 	Primary            string
 	ReplicationTimeout int //milliseconds
+	MaxReplicationPack int // maximum number of JWTS to grab on startup
 }
 
 // TLSConf holds the configuration for a TLS connection/server
@@ -97,5 +98,6 @@ func DefaultServerConfig() *AccountServerConfig {
 		},
 		Store:              StoreConfig{}, // in memory store
 		ReplicationTimeout: 5000,
+		MaxReplicationPack: 10000,
 	}
 }

--- a/server/core/handlers_accounts.go
+++ b/server/core/handlers_accounts.go
@@ -17,7 +17,7 @@
 package core
 
 import (
-	"fmt"
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -80,14 +80,15 @@ func (server *AccountServer) UpdateAccountJWT(w http.ResponseWriter, r *http.Req
 	claim.Validate(vr)
 
 	if vr.IsBlocking(true) {
-		var lines []string
-		lines = append(lines, "The server was unable to update your account JWT. One more more validation issues occurred.")
-		for _, vi := range vr.Issues {
-			lines = append(lines, fmt.Sprintf("\t - %s\n", vi.Description))
+		validationResults, err := json.Marshal(vr)
+
+		if err != nil {
+			server.sendErrorResponse(http.StatusInternalServerError, "unable to marshal JWT validation", shortCode, err, w)
+			return
 		}
-		msg := strings.Join(lines, "\n")
+
 		server.logger.Errorf("attempt to update JWT %s with blocking validation errors", shortCode)
-		http.Error(w, msg, http.StatusBadRequest)
+		http.Error(w, string(validationResults), http.StatusBadRequest)
 		return
 	}
 

--- a/server/core/handlers_pack.go
+++ b/server/core/handlers_pack.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package core
+
+import (
+	"fmt"
+	"github.com/nats-io/nats-account-server/server/store"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// PackJWTs the JWTS and return
+// takes a parameter for max
+func (server *AccountServer) PackJWTs(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
+	server.logger.Tracef("%s: %s", r.RemoteAddr, r.URL.String())
+
+	maxStr := strings.ToLower(r.URL.Query().Get("max"))
+
+	if maxStr == "" {
+		maxStr = "-1"
+	}
+
+	max, err := strconv.Atoi(maxStr)
+
+	if err != nil {
+		server.sendErrorResponse(http.StatusBadRequest, fmt.Sprintf("bad max parameter %q", maxStr), "", err, w)
+		return
+	}
+
+	server.logger.Tracef("request for JWT Pack - max=%d", max)
+
+	packer, ok := server.jwtStore.(store.PackableJWTStore)
+	if !ok {
+		server.sendErrorResponse(http.StatusBadRequest, "pack isn't supported", "", nil, w)
+		return
+	}
+
+	pack, err := packer.Pack(max)
+	if err != nil {
+		server.sendErrorResponse(http.StatusInternalServerError, "error packing JWTs", "", err, w)
+		return
+	}
+
+	w.Header().Add(ContentType, TextPlain)
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write([]byte(pack))
+
+	if err != nil {
+		server.logger.Errorf("error writing JWT Pack - %s", err.Error())
+	} else {
+		server.logger.Tracef("returning JWT Pack")
+	}
+}

--- a/server/core/handlers_pack_test.go
+++ b/server/core/handlers_pack_test.go
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2019 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package core
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/nats-io/jwt"
+	"github.com/nats-io/nats-account-server/server/conf"
+	"github.com/nats-io/nkeys"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackJWTs(t *testing.T) {
+
+	testEnv, err := SetupTestServer(conf.DefaultServerConfig(), false, false)
+	defer testEnv.Cleanup()
+	require.NoError(t, err)
+
+	operatorKey := testEnv.OperatorKey
+
+	pubKeys := map[string]string{}
+
+	for i := 0; i < 100; i++ {
+		accountKey, err := nkeys.CreateAccount()
+		require.NoError(t, err)
+
+		pubKey, err := accountKey.PublicKey()
+		require.NoError(t, err)
+
+		account := jwt.NewAccountClaims(pubKey)
+		acctJWT, err := account.Encode(operatorKey)
+		require.NoError(t, err)
+
+		pubKeys[pubKey] = acctJWT
+
+		path := fmt.Sprintf("/jwt/v1/accounts/%s", pubKey)
+		url := testEnv.URLForPath(path)
+
+		resp, err := testEnv.HTTP.Post(url, "application/json", bytes.NewBuffer([]byte(acctJWT)))
+		require.NoError(t, err)
+		require.True(t, resp.StatusCode == http.StatusOK)
+	}
+
+	resp, err := testEnv.HTTP.Get(testEnv.URLForPath("/jwt/v1/pack"))
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	pack := string(body)
+	split := strings.Split(pack, "\n")
+
+	for _, line := range split {
+		if line == "" {
+			continue
+		}
+
+		s := strings.Split(line, "|")
+		require.Len(t, s, 2)
+
+		pubKey := s[0]
+		jwt := s[1]
+
+		existing, ok := pubKeys[pubKey]
+		require.True(t, ok)
+		require.NotEmpty(t, existing)
+		require.Equal(t, existing, jwt)
+	}
+}
+
+func TestPackJWTsWithMax(t *testing.T) {
+
+	testEnv, err := SetupTestServer(conf.DefaultServerConfig(), false, false)
+	defer testEnv.Cleanup()
+	require.NoError(t, err)
+
+	operatorKey := testEnv.OperatorKey
+
+	pubKeys := map[string]string{}
+
+	for i := 0; i < 100; i++ {
+		accountKey, err := nkeys.CreateAccount()
+		require.NoError(t, err)
+
+		pubKey, err := accountKey.PublicKey()
+		require.NoError(t, err)
+
+		account := jwt.NewAccountClaims(pubKey)
+		acctJWT, err := account.Encode(operatorKey)
+		require.NoError(t, err)
+
+		pubKeys[pubKey] = acctJWT
+
+		path := fmt.Sprintf("/jwt/v1/accounts/%s", pubKey)
+		url := testEnv.URLForPath(path)
+
+		resp, err := testEnv.HTTP.Post(url, "application/json", bytes.NewBuffer([]byte(acctJWT)))
+		require.NoError(t, err)
+		require.True(t, resp.StatusCode == http.StatusOK)
+	}
+
+	resp, err := testEnv.HTTP.Get(testEnv.URLForPath("/jwt/v1/pack?max=2"))
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == http.StatusOK)
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	pack := string(body)
+	split := strings.Split(pack, "\n")
+
+	require.Len(t, split, 2)
+
+	for _, line := range split {
+		s := strings.Split(line, "|")
+		require.Len(t, s, 2)
+
+		pubKey := s[0]
+		jwt := s[1]
+
+		existing, ok := pubKeys[pubKey]
+		require.True(t, ok)
+		require.NotEmpty(t, existing)
+		require.Equal(t, existing, jwt)
+	}
+}
+
+func TestReplicatedInit(t *testing.T) {
+	testEnv, err := SetupTestServer(conf.DefaultServerConfig(), false, true)
+	defer testEnv.Cleanup()
+	require.NoError(t, err)
+
+	operatorKey := testEnv.OperatorKey
+
+	pubKeys := map[string]string{}
+
+	for i := 0; i < 100; i++ {
+		accountKey, err := nkeys.CreateAccount()
+		require.NoError(t, err)
+
+		pubKey, err := accountKey.PublicKey()
+		require.NoError(t, err)
+
+		account := jwt.NewAccountClaims(pubKey)
+		acctJWT, err := account.Encode(operatorKey)
+		require.NoError(t, err)
+
+		pubKeys[pubKey] = acctJWT
+
+		path := fmt.Sprintf("/jwt/v1/accounts/%s", pubKey)
+		url := testEnv.URLForPath(path)
+
+		resp, err := testEnv.HTTP.Post(url, "application/json", bytes.NewBuffer([]byte(acctJWT)))
+		require.NoError(t, err)
+		require.True(t, resp.StatusCode == http.StatusOK)
+	}
+
+	// Now start up the replica
+	tempDir, err := ioutil.TempDir(os.TempDir(), "prefix")
+	require.NoError(t, err)
+
+	replica, err := testEnv.CreateReplica(tempDir)
+	require.NoError(t, err)
+	defer replica.Stop()
+
+	// Turn off the main server, so we only get local content from the replica
+	testEnv.Server.Stop()
+
+	// Replica should have initialized
+	for pubkey, jwt := range pubKeys {
+		path := fmt.Sprintf("/jwt/v1/accounts/%s", pubkey)
+		url := fmt.Sprintf("%s://%s%s", replica.protocol, replica.hostPort, path)
+		resp, err := testEnv.HTTP.Get(url)
+		require.NoError(t, err)
+		require.True(t, resp.StatusCode == http.StatusOK)
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, jwt, string(body))
+	}
+}
+
+func TestReplicatedInitWithMax(t *testing.T) {
+	testEnv, err := SetupTestServer(conf.DefaultServerConfig(), false, true)
+	defer testEnv.Cleanup()
+	require.NoError(t, err)
+
+	operatorKey := testEnv.OperatorKey
+
+	pubKeys := map[string]string{}
+
+	for i := 0; i < 100; i++ {
+		accountKey, err := nkeys.CreateAccount()
+		require.NoError(t, err)
+
+		pubKey, err := accountKey.PublicKey()
+		require.NoError(t, err)
+
+		account := jwt.NewAccountClaims(pubKey)
+		acctJWT, err := account.Encode(operatorKey)
+		require.NoError(t, err)
+
+		pubKeys[pubKey] = acctJWT
+
+		path := fmt.Sprintf("/jwt/v1/accounts/%s", pubKey)
+		url := testEnv.URLForPath(path)
+
+		resp, err := testEnv.HTTP.Post(url, "application/json", bytes.NewBuffer([]byte(acctJWT)))
+		require.NoError(t, err)
+		require.True(t, resp.StatusCode == http.StatusOK)
+	}
+
+	// Now start up the replica
+	tempDir, err := ioutil.TempDir(os.TempDir(), "prefix")
+	require.NoError(t, err)
+
+	replica, err := testEnv.CreateReplicaWithMaxPack(tempDir, 10)
+	require.NoError(t, err)
+	defer replica.Stop()
+
+	// Turn off the main server, so we only get local content from the replica
+	testEnv.Server.Stop()
+
+	count := 0
+
+	// Replica should have initialized
+	for pubkey, jwt := range pubKeys {
+		path := fmt.Sprintf("/jwt/v1/accounts/%s", pubkey)
+		url := fmt.Sprintf("%s://%s%s", replica.protocol, replica.hostPort, path)
+		resp, err := testEnv.HTTP.Get(url)
+
+		// only count the ones that we have
+		if err == nil && resp.StatusCode == http.StatusOK {
+			body, err := ioutil.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.Equal(t, jwt, string(body))
+			count++
+		}
+	}
+
+	require.Equal(t, 10, count)
+}
+
+func TestReplicatedInitWithMaxZero(t *testing.T) {
+	testEnv, err := SetupTestServer(conf.DefaultServerConfig(), false, true)
+	defer testEnv.Cleanup()
+	require.NoError(t, err)
+
+	operatorKey := testEnv.OperatorKey
+
+	pubKeys := map[string]string{}
+
+	for i := 0; i < 100; i++ {
+		accountKey, err := nkeys.CreateAccount()
+		require.NoError(t, err)
+
+		pubKey, err := accountKey.PublicKey()
+		require.NoError(t, err)
+
+		account := jwt.NewAccountClaims(pubKey)
+		acctJWT, err := account.Encode(operatorKey)
+		require.NoError(t, err)
+
+		pubKeys[pubKey] = acctJWT
+
+		path := fmt.Sprintf("/jwt/v1/accounts/%s", pubKey)
+		url := testEnv.URLForPath(path)
+
+		resp, err := testEnv.HTTP.Post(url, "application/json", bytes.NewBuffer([]byte(acctJWT)))
+		require.NoError(t, err)
+		require.True(t, resp.StatusCode == http.StatusOK)
+	}
+
+	// Now start up the replica
+	tempDir, err := ioutil.TempDir(os.TempDir(), "prefix")
+	require.NoError(t, err)
+
+	replica, err := testEnv.CreateReplicaWithMaxPack(tempDir, 0)
+	require.NoError(t, err)
+	defer replica.Stop()
+
+	// Turn off the main server, so we only get local content from the replica
+	testEnv.Server.Stop()
+
+	count := 0
+
+	// Replica should have initialized
+	for pubkey, jwt := range pubKeys {
+		path := fmt.Sprintf("/jwt/v1/accounts/%s", pubkey)
+		url := fmt.Sprintf("%s://%s%s", replica.protocol, replica.hostPort, path)
+		resp, err := testEnv.HTTP.Get(url)
+
+		// only count the ones that we have
+		if err == nil && resp.StatusCode == http.StatusOK {
+			body, err := ioutil.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.Equal(t, jwt, string(body))
+			count++
+		}
+	}
+
+	require.Equal(t, 0, count)
+}

--- a/server/core/http.go
+++ b/server/core/http.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/nats-io/nats-account-server/server/store"
 	"net"
 	"net/http"
 	"strings"
@@ -180,6 +181,11 @@ func (server *AccountServer) buildRouter() *httprouter.Router {
 	if !server.jwtStore.IsReadOnly() && server.primary == "" {
 		r.POST("/jwt/v1/accounts/:pubkey", server.UpdateAccountJWT)
 		r.POST("/jwt/v1/activations", server.UpdateActivationJWT)
+	}
+
+	_, ok := server.jwtStore.(store.PackableJWTStore)
+	if ok {
+		r.GET("/jwt/v1/pack", server.PackJWTs)
 	}
 
 	r.GET("/jwt/v1/accounts/:pubkey", server.GetAccountJWT)

--- a/server/core/server_test.go
+++ b/server/core/server_test.go
@@ -226,6 +226,14 @@ func (ts *TestSetup) CreateReplica(dir string) (*AccountServer, error) {
 	return replica, replica.Start()
 }
 
+func (ts *TestSetup) CreateReplicaWithMaxPack(dir string, maxReplicationPack int) (*AccountServer, error) {
+	config := ts.CreateReplicaConfig(dir)
+	config.MaxReplicationPack = maxReplicationPack
+	replica := NewAccountServer()
+	replica.InitializeFromConfig(config)
+	return replica, replica.Start()
+}
+
 var port = uint64(14222)
 
 // SetupTestServer creates an operator, gnatsd, context, config and test http server with a router

--- a/server/store/dirstore_test.go
+++ b/server/store/dirstore_test.go
@@ -17,6 +17,8 @@
 package store
 
 import (
+	"github.com/nats-io/jwt"
+	"github.com/nats-io/nkeys"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -346,4 +348,194 @@ func TestUnShardedDirStoreNotifications(t *testing.T) {
 
 	store.Close()
 	readOnlyStore.Close()
+}
+
+func TestShardedDirStorePackMerge(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
+	require.NoError(t, err)
+	dir2, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
+	require.NoError(t, err)
+	dir3, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
+	require.NoError(t, err)
+
+	store, err := NewDirJWTStore(dir, true, false, nil, nil)
+	require.NoError(t, err)
+
+	expected := map[string]string{
+		"one":   "alpha",
+		"two":   "beta",
+		"three": "gamma",
+		"four":  "delta",
+	}
+
+	require.False(t, store.IsReadOnly())
+
+	for k, v := range expected {
+		store.Save(k, v)
+	}
+
+	for k, v := range expected {
+		got, err := store.Load(k)
+		require.NoError(t, err)
+		require.Equal(t, v, got)
+	}
+
+	got, err := store.Load("random")
+	require.Error(t, err)
+	require.Equal(t, "", got)
+
+	packable, ok := store.(PackableJWTStore)
+	require.True(t, ok)
+
+	pack, err := packable.Pack(-1)
+	require.NoError(t, err)
+
+	inc, err := NewDirJWTStore(dir2, true, false, nil, nil)
+	require.NoError(t, err)
+
+	incP, ok := inc.(PackableJWTStore)
+	require.True(t, ok)
+
+	incP.Merge(pack)
+
+	for k, v := range expected {
+		got, err := inc.Load(k)
+		require.NoError(t, err)
+		require.Equal(t, v, got)
+	}
+
+	got, err = inc.Load("random")
+	require.Error(t, err)
+	require.Equal(t, "", got)
+
+	limitedPack, err := packable.Pack(1)
+	require.NoError(t, err)
+
+	limited, err := NewDirJWTStore(dir3, true, false, nil, nil)
+
+	require.NoError(t, err)
+	limitedP, ok := limited.(PackableJWTStore)
+	require.True(t, ok)
+
+	limitedP.Merge(limitedPack)
+
+	count := 0
+	for k, v := range expected {
+		got, err := limited.Load(k)
+		if err == nil {
+			count++
+			require.Equal(t, v, got)
+		}
+	}
+
+	require.Equal(t, 1, count)
+
+	got, err = inc.Load("random")
+	require.Error(t, err)
+	require.Equal(t, "", got)
+}
+
+func TestShardedToUnsharedDirStorePackMerge(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
+	require.NoError(t, err)
+	dir2, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
+	require.NoError(t, err)
+
+	store, err := NewDirJWTStore(dir, true, false, nil, nil)
+	require.NoError(t, err)
+
+	expected := map[string]string{
+		"one":   "alpha",
+		"two":   "beta",
+		"three": "gamma",
+		"four":  "delta",
+	}
+
+	require.False(t, store.IsReadOnly())
+
+	for k, v := range expected {
+		store.Save(k, v)
+	}
+
+	for k, v := range expected {
+		got, err := store.Load(k)
+		require.NoError(t, err)
+		require.Equal(t, v, got)
+	}
+
+	got, err := store.Load("random")
+	require.Error(t, err)
+	require.Equal(t, "", got)
+
+	packable, ok := store.(PackableJWTStore)
+	require.True(t, ok)
+
+	pack, err := packable.Pack(-1)
+	require.NoError(t, err)
+
+	inc, err := NewDirJWTStore(dir2, false, false, nil, nil)
+	require.NoError(t, err)
+
+	incP, ok := inc.(PackableJWTStore)
+	require.True(t, ok)
+
+	incP.Merge(pack)
+
+	for k, v := range expected {
+		got, err := inc.Load(k)
+		require.NoError(t, err)
+		require.Equal(t, v, got)
+	}
+
+	got, err = inc.Load("random")
+	require.Error(t, err)
+	require.Equal(t, "", got)
+}
+
+func TestMergeOnlyOnNewer(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "jwtstore_test")
+	require.NoError(t, err)
+
+	store, err := NewDirJWTStore(dir, true, false, func(pubKey string) {}, func(err error) {})
+	require.NoError(t, err)
+
+	dirStore := store.(*DirJWTStore)
+
+	accountKey, err := nkeys.CreateAccount()
+	require.NoError(t, err)
+
+	pubKey, err := accountKey.PublicKey()
+	require.NoError(t, err)
+
+	account := jwt.NewAccountClaims(pubKey)
+	account.Name = "old"
+	olderJWT, err := account.Encode(accountKey)
+	require.NoError(t, err)
+
+	time.Sleep(2 * time.Second)
+
+	account.Name = "new"
+	newerJWT, err := account.Encode(accountKey)
+	require.NoError(t, err)
+
+	// Should work
+	err = dirStore.Save(pubKey, olderJWT)
+	require.NoError(t, err)
+	fromStore, err := dirStore.Load(pubKey)
+	require.NoError(t, err)
+	require.Equal(t, olderJWT, fromStore)
+
+	// should replace
+	err = dirStore.saveIfNewer(pubKey, newerJWT)
+	require.NoError(t, err)
+	fromStore, err = dirStore.Load(pubKey)
+	require.NoError(t, err)
+	require.Equal(t, newerJWT, fromStore)
+
+	// should fail
+	err = dirStore.saveIfNewer(pubKey, olderJWT)
+	require.NoError(t, err)
+	fromStore, err = dirStore.Load(pubKey)
+	require.NoError(t, err)
+	require.Equal(t, newerJWT, fromStore)
 }

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -25,3 +25,18 @@ type JWTStore interface {
 	IsReadOnly() bool
 	Close()
 }
+
+// PackableJWTStore is implemented by stores that can pack up their content or
+// merge content from another stores pack. The format of a packed store is a
+// single string with 1 JWT per line, \n is as the line separator. The line format is:
+// pubkey|encodedjwt\n
+// Stores with locking may be locked during pack/merge which should be considered
+// in very high performance situations.
+// No preference is required on the JWTs included if maxJWTS is less than the total, that
+// is store dependent. Merge implies writability and does not check the "is readonly" flag
+// of a store
+type PackableJWTStore interface {
+	// Pack the jwts, up to maxJWTs. If maxJWTs is negative, do not limit.
+	Pack(maxJWTs int) (string, error)
+	Merge(pack string) error
+}


### PR DESCRIPTION
Configurable max size, defaults to 10k
Replicas grab JWTs on startup before they turn on HTTP
Directory store uses "save if newer" behavior
Memory store also supports for testing
Tests abound