### PR TITLE
Update Dockerfile to use go1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.4 AS builder
+FROM golang:1.16-alpine3.13 AS builder
 
 WORKDIR /src/nats-account-server
 
@@ -10,7 +10,7 @@ COPY . .
 RUN go mod download
 RUN CGO_ENABLED=0 go build -v -a -tags netgo -installsuffix netgo -o /nats-account-server
 
-FROM alpine:3.9
+FROM alpine:3.13
 
 RUN apk add --update ca-certificates && mkdir -p /nats/bin && mkdir /nats/conf
 


### PR DESCRIPTION
`limit = 1_000` isn't supported in `Go` version prior to go1.13, that's why `docker build` was failing.

So, I updated the docker base image to `1.16-alpine3.13` and `alpine:3.13`.