### PR TITLE
[Added] warning when using disabled read only feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func expandPath(p string) string {
 func main() {
 	var server *core.AccountServer
 	disabledNscFolder := ""
+	disabledReadOnly := false
 	flags := core.Flags{}
 	flag.StringVar(&flags.ConfigFile, "c", "", "configuration filepath, other flags take precedent over the config file")
 	flag.StringVar(&flags.Directory, "dir", "", "the directory to store/host accounts with, mututally exclusive from nsc")
@@ -60,6 +61,7 @@ func main() {
 	flag.BoolVar(&flags.DebugAndVerbose, "DV", false, "turn on debug and verbose logging")
 	flag.StringVar(&flags.HostPort, "hp", "", "http hostport, defaults to localhost:9090")
 	flag.StringVar(&disabledNscFolder, "nsc", "", core.NscError)
+	flag.BoolVar(&disabledReadOnly, "ro", false, core.RoError)
 	flag.Parse()
 
 	// resolve paths with dots/tildes
@@ -84,6 +86,9 @@ func main() {
 
 	if disabledNscFolder != "" {
 		logStopExit(server, fmt.Errorf(core.NscError))
+	}
+	if disabledReadOnly {
+		logStopExit(server, fmt.Errorf(core.RoError))
 	}
 
 	go func() {

--- a/server/conf/conf.go
+++ b/server/conf/conf.go
@@ -86,7 +86,8 @@ type StoreConfig struct {
 	Shard           bool   // optional setting to shard the directory store, avoiding too many files in one folder
 	CleanupInterval int    // interval at which expiration is checked
 
-	NSC string // removed support for this, keep so that we can warn when used
+	NSC      string // removed support for this, keep so that we can warn when used
+	ReadOnly bool   // removed support for this, keep so that we can warn when used
 }
 
 // DefaultServerConfig generates a default configuration with

--- a/server/core/server.go
+++ b/server/core/server.go
@@ -276,14 +276,21 @@ func (server *AccountServer) jwtChangedCallback(pubKey string) {
 	}
 }
 
-const NscError = `support for direct access of the nsc folder has been removed
-use a dedicated store directory and specify the operator jwt path
+const commonErr = `
+use a dedicated store directory and specify the operator jwt path instead
 synchronize using: nsc push --all --account-jwt-server-url <account-server-host-port>/jwt/v1`
+
+const RoError = `support for read only directory access with file system updates has been removed` + commonErr
+
+const NscError = `support for direct access of the nsc folder has been removed` + commonErr
 
 func (server *AccountServer) createStore() (store.JWTStore, error) {
 	config := server.config.Store
 	if config.NSC != "" {
 		return nil, fmt.Errorf(NscError)
+	}
+	if config.ReadOnly {
+		return nil, fmt.Errorf(RoError)
 	}
 	if config.Dir == "" {
 		return nil, fmt.Errorf("store directory is required")


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>

```
./nats-account-server -ro
2021/03/15 21:22:53 support for read only directory access with file system updates has been removed
use a dedicated store directory and specify the operator jwt path instead
synchronize using: nsc push --all --account-jwt-server-url <account-server-host-port>/jwt/v1
```