### PR TITLE
fixes related to internal sign request subject

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -9,7 +9,6 @@ github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/julienschmidt/httprouter v1.2.0 h1:TDTW5Yz1mjftljbcKqRcrYhd4XeOoI98t+9HbQbYf7g=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
@@ -83,7 +82,6 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 h1:NusfzzA6yGQ+ua51ck7E3omNUX/JuqbFSaRGqU8CcLI=
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/server/core/nats.go
+++ b/server/core/nats.go
@@ -257,25 +257,25 @@ func (server *AccountServer) sendAccountNotification(pubKey string, theJWT []byt
 	return server.nats.Publish(subject, theJWT)
 }
 
-func (s *AccountServer) respondToUpdate(msg *nats.Msg, acc string, message string, err error) {
+func (server *AccountServer) respondToUpdate(msg *nats.Msg, acc string, message string, err error) {
 	if err == nil {
-		s.logger.Debugf("%s - %s", message, acc)
+		server.logger.Debugf("%s - %s", message, acc)
 	} else {
-		s.logger.Errorf("%s - %s - %s", message, acc, err)
+		server.logger.Errorf("%s - %s - %s", message, acc, err)
 	}
 	if msg.Reply == "" {
 		return
 	}
 	host, _ := os.Hostname()
-	s.Lock() // ties seqNo increment and send together
-	s.respSeqNo++
-	defer s.Unlock()
+	server.Lock() // ties seqNo increment and send together
+	server.respSeqNo++
+	defer server.Unlock()
 	response := map[string]interface{}{"server": map[string]interface{}{
 		"name": "nats-account-server",
 		"host": host,
 		"ver":  version,
-		"seq":  s.respSeqNo,
-		"id":   s.id,
+		"seq":  server.respSeqNo,
+		"id":   server.id,
 		"time": time.Now(),
 	}}
 	if err == nil {
@@ -292,7 +292,7 @@ func (s *AccountServer) respondToUpdate(msg *nats.Msg, acc string, message strin
 		}
 	}
 	if m, err := json.MarshalIndent(response, "", "  "); err != nil {
-		s.logger.Errorf("Marshaling error: %v", err)
+		server.logger.Errorf("Marshaling error: %v", err)
 	} else {
 		msg.Respond(m)
 	}

--- a/server/core/server.go
+++ b/server/core/server.go
@@ -75,6 +75,10 @@ func NewAccountServer() *AccountServer {
 	return ac
 }
 
+func (server *AccountServer) Config() *conf.AccountServerConfig {
+	return server.config
+}
+
 // ConfigureLogger configures the logger for this account server
 func (server *AccountServer) ConfigureLogger() natsserver.Logger {
 	opts := server.config.Logging
@@ -112,7 +116,7 @@ func (server *AccountServer) InitializeFromFlags(flags Flags) error {
 			return err
 		}
 	}
-	server.ConfigureLogger()
+	server.logger = server.ConfigureLogger()
 
 	if flags.Directory != "" {
 		server.config.Store = conf.StoreConfig{
@@ -122,8 +126,6 @@ func (server *AccountServer) InitializeFromFlags(flags Flags) error {
 
 	if flags.NATSURL != "" {
 		server.config.NATS.Servers = []string{flags.NATSURL}
-	} else if server.config.SignRequestSubject != "" {
-		return fmt.Errorf("nats configuration is required in order to issue signature requests")
 	}
 
 	if flags.Creds != "" {
@@ -198,7 +200,6 @@ func (server *AccountServer) Start() error {
 
 	server.running = true
 	server.startTime = time.Now()
-	server.logger = server.ConfigureLogger()
 
 	server.logger.Noticef("starting NATS Account server, version %s", version)
 	server.logger.Noticef("server time is %s", server.startTime.Format(time.UnixDate))


### PR DESCRIPTION
[FIX] the logger setup to happen earlier so that any errors can be seen
[RENAME] renamed references to `s` to `server` to be consistent with all the receivers for the `AccountServer`
[FEAT] added `--dump` to get a printout of the server configuration as the server understands it.
[FIX] removed a check when setting flags for SignRequestSubject - this validation is out of place and prevents the server from starting when the setting is configured