### PR TITLE
fix staticcheck error S1017

### DIFF
--- a/server/core/server.go
+++ b/server/core/server.go
@@ -368,9 +368,7 @@ func (server *AccountServer) initializeFromPrimary() error {
 
 	server.logger.Noticef("grabbing initial JWT pack from primary %s", primary)
 
-	if strings.HasSuffix(primary, "/") {
-		primary = primary[:len(primary)-1]
-	}
+	primary = strings.TrimSuffix(primary, "/")
 
 	url := fmt.Sprintf("%s/jwt/v1/pack?max=%d", primary, server.config.MaxReplicationPack)
 


### PR DESCRIPTION
Fix solves the staticcheck error [S1017](https://staticcheck.io/docs/checks#S1017) when running make.

```
staticcheck ./...
server/core/server.go:371:2: should replace this if statement with an unconditional strings.TrimSuffix (S1017)
```

