### PR TITLE
Add multiarch rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ check:
 update:
 	go get -u honnef.co/go/tools/cmd/staticcheck
 	go get -u github.com/client9/misspell/cmd/misspell
-  
+
 compile:
 	go build ./...
 
@@ -44,3 +44,17 @@ fasttest:
 
 failfast:
 	go test -tags test -race -failfast ./...
+
+.PHONY: dockerx
+dockerx:
+ifneq ($(ver),)
+	# Ensure 'docker buildx ls' shows correct platforms.
+	docker buildx build \
+		--tag natsio/nats-account-server:$(ver) --tag natsio/nats-account-server:latest \
+		--platform linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8 \
+		--push .
+else
+	# Missing version, try this.
+	# make dockerx ver=1.2.3
+	exit 1
+endif


### PR DESCRIPTION
This adds rules to build multi-arch Docker images. A working BuildKit builder is required for creating these images. See more documentation at: https://docs.docker.com/buildx/working-with-buildx

Assuming a working builder, then all we need to do is this.
```
make dockerx ver=1.2.3
```

These are the arches that are created:
![image](https://user-images.githubusercontent.com/4296393/128097374-facb7a8b-1759-4f61-b456-5f112af984c8.png)

I tested the linux/arm64 images on Ubuntu ARM64.
```
$ uname -a
Linux aws #43~20.04.1-Ubuntu SMP Thu Jul 15 11:03:27 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
```