### PR TITLE
[UPDATE] disable CGO in build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,8 @@ builds:
   goarm:
   - 6
   - 7
+  env:
+  - CGO_ENABLED=0
   ignore:
     - goos: darwin
       goarch: 386


### PR DESCRIPTION
Currently the goreleaser builds with CGO enabled, which I do not believe is necessary for this project